### PR TITLE
Fix ignoring duration property for reoccuring events

### DIFF
--- a/ical_events.js
+++ b/ical_events.js
@@ -15,6 +15,9 @@ function jcal_events(jcal, event_callback, recur_event_callback) {
 }
 
 function event_duration(event) {
+    if (event.getFirstPropertyValue('duration') !== null) {
+      return event.getFirstPropertyValue('duration').toSeconds() * 1000;
+    }
     return new Date(event.getFirstPropertyValue('dtend').toJSDate() - event.getFirstPropertyValue('dtstart').toJSDate()).getTime()
 }
 
@@ -37,4 +40,3 @@ function expand_recur_event(event, dtstart, dtend, event_callback) {
         }
     }
 }
-


### PR DESCRIPTION
E.g. a meeting which takes 1 hour and takes place every week.