### PR TITLE
IE9+ support patch

### DIFF
--- a/demo/colorize_fullcalendar.js
+++ b/demo/colorize_fullcalendar.js
@@ -11,11 +11,11 @@ function hash_color(string) {
 }
 
 function colorize_event(e) {
-    for (c of e.classList) {
-       if (c.startsWith('event-')) {
-           e.style['background'] = e.style['border-color'] = hash_color(c)
-       }
-    }     
+    e.classList.forEach(function(c, i){
+      if (c.startsWith('event-')) {
+          e.style['background'] = e.style['border-color'] = hash_color(c)
+      }
+    });
 }
 
 function colorize_events() {
@@ -26,5 +26,3 @@ function colorize_events() {
         } catch (TypeError) {}
     }
 }
-
-

--- a/demo/colorize_fullcalendar.js
+++ b/demo/colorize_fullcalendar.js
@@ -15,7 +15,7 @@ function colorize_event(e) {
       if (c.startsWith('event-')) {
           e.style['background'] = e.style['border-color'] = hash_color(c)
       }
-    });
+    })
 }
 
 function colorize_events() {

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -39,9 +39,8 @@ $(document).ready(function() {
         defaultDate: '2016-03-01'
     })
     sources_to_load_cnt = ics_sources.length
-    for (ics of ics_sources) {
-        load_ics(ics)
-    }
+    ics_sources.forEach(function(ics){
+      load_ics(ics);
+    });
     add_recur_events()
 })
-

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -40,7 +40,7 @@ $(document).ready(function() {
     })
     sources_to_load_cnt = ics_sources.length
     ics_sources.forEach(function(ics){
-      load_ics(ics);
-    });
+      load_ics(ics)
+    })
     add_recur_events()
 })

--- a/ical_events.js
+++ b/ical_events.js
@@ -5,15 +5,15 @@ function ical_events(ical, event_callback, recur_event_callback) {
 }
 
 function jcal_events(jcal, event_callback, recur_event_callback) {
-    var vcalendar_comp = new ICAL.Component(jcal);
+    var vcalendar_comp = new ICAL.Component(jcal)
     var vevents_comp = vcalendar_comp.getAllSubcomponents('vevent');
     vevents_comp.forEach(function(vvent, i){
       if( vvent.hasProperty('rrule') ){
-        recur_event_callback(vvent);
+        recur_event_callback(vvent)
       } else {
-        event_callback(vvent);
+        event_callback(vvent)
       }
-    });
+    })
 }
 
 function event_duration(event) {

--- a/ical_events.js
+++ b/ical_events.js
@@ -5,13 +5,15 @@ function ical_events(ical, event_callback, recur_event_callback) {
 }
 
 function jcal_events(jcal, event_callback, recur_event_callback) {
-    for (event of new ICAL.Component(jcal).getAllSubcomponents('vevent')) {
-        if (event.hasProperty('rrule')) {
-            recur_event_callback(event)
-        } else {
-            event_callback(event)
-        }
-    }
+    var vcalendar_comp = new ICAL.Component(jcal);
+    var vevents_comp = vcalendar_comp.getAllSubcomponents('vevent');
+    vevents_comp.forEach(function(vvent, i){
+      if( vvent.hasProperty('rrule') ){
+        recur_event_callback(vvent);
+      } else {
+        event_callback(vvent);
+      }
+    });
 }
 
 function event_duration(event) {
@@ -37,4 +39,3 @@ function expand_recur_event(event, dtstart, dtend, event_callback) {
         }
     }
 }
-

--- a/ical_fullcalendar.js
+++ b/ical_fullcalendar.js
@@ -14,14 +14,14 @@ function moment_icaltime(moment, timezone) {
 
 function expand_recur_events(start, end, timezone, events_callback) {
     events = []
-    for (event of recur_events) {
-	event_properties = event.event_properties
-        expand_recur_event(event, moment_icaltime(start, timezone), moment_icaltime(end, timezone), function(event){
-            fc_event(event, function(event){
-                events.push(merge_events(event_properties, merge_events({className:['recur-event']}, event)))
-            })
+    recur_events.forEach(function(event, i){
+      event_properties = event.event_properties;
+      expand_recur_event(event, moment_icaltime(start, timezone), moment_icaltime(end, timezone), function(event){
+        fc_event(event, function(event){
+          events.push(merge_events(event_properties, merge_events({className:['recur-event']}, event)))
         })
-    }
+      })
+    });
     events_callback(events)
 }
 
@@ -75,4 +75,3 @@ function fc_event(event, event_callback) {
     }
     event_callback(e)
 }
-

--- a/ical_fullcalendar.js
+++ b/ical_fullcalendar.js
@@ -15,13 +15,13 @@ function moment_icaltime(moment, timezone) {
 function expand_recur_events(start, end, timezone, events_callback) {
     events = []
     recur_events.forEach(function(event, i){
-      event_properties = event.event_properties;
+      event_properties = event.event_properties
       expand_recur_event(event, moment_icaltime(start, timezone), moment_icaltime(end, timezone), function(event){
         fc_event(event, function(event){
           events.push(merge_events(event_properties, merge_events({className:['recur-event']}, event)))
         })
       })
-    });
+    })
     events_callback(events)
 }
 


### PR DESCRIPTION
Added support for IE9 and beyond. Unfortunately, no version of IE supports the `for...of` statement. The code replaces all instances with the `foreach` statement, which is supported by IE as of IE9 and beyond.

btw awesome work @leonaard, your repo saved me a lot of time. Thanks for the share.